### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/ilias2nbgrader/preprocessors/renamenotebooks.py
+++ b/ilias2nbgrader/preprocessors/renamenotebooks.py
@@ -1,4 +1,4 @@
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from .preprocessor import Preprocessor
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,7 @@ setup(
     author_email='tim.metzler@h-brs.de',
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=[
-        "fuzzywuzzy",
-        "python-Levenshtein",
+        "rapidfuzz",
         "nbformat"
     ],
     include_package_data = True,


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it faster than FuzzyWuzzy.